### PR TITLE
Fix a problem that 0th item is selected at the init of Fcitx5

### DIFF
--- a/src/virtualkeyboardi18n.cpp
+++ b/src/virtualkeyboardi18n.cpp
@@ -110,9 +110,26 @@ bool I18nKeyboard::containInputMethod(
     return iter != items.end();
 }
 
-void I18nKeyboard::syncState(VirtualKeyboard *, const std::string &) {
-    // Do nothing.
-    // Override this if need to do some processes depending on the launguage.
+void I18nKeyboard::syncState(
+    VirtualKeyboard *keyboard,
+    const std::string &currentInputMethodName
+) {
+    // Always fix to this keyboard's input-method
+
+    // Note: The 0th item in each group is usually set to a simple keyboard
+    // such as `keyboard-us`, but most virtual keyboards using IME add-ons
+    // don't use the 0th item and use only the 1th item, which is the IME for
+    // the keyboard's language.
+    // Such keyboards do not normally select the 0th item, but it is possible
+    // that the 0th item is selected at the initiation of Fcitx5, so this process
+    // is necessary.
+    // On the other hand, for keyboards like AnthyKeyboard that have the function of
+    // switching items, this process should not be used and should be overridden.
+
+    if (imeNames[type()] == currentInputMethodName) {
+        return;
+    }
+    keyboard->setCurrentInputMethod(imeNames[type()]);
 }
 
 }

--- a/src/virtualkeyboardi18n.h
+++ b/src/virtualkeyboardi18n.h
@@ -41,10 +41,14 @@ public:
     virtual const char *label() const = 0;
     virtual void updateKeys() = 0;
     virtual const std::string languageCode() const { return ""; }
+
+    /// Override this if you need to do language-specific sync-process
+    /// (especially if you need to switch items within one group as in AnthyKeyboard).
     virtual void syncState(
         VirtualKeyboard *keyboard,
         const std::string &currentInputMethodName
     );
+
     std::vector<std::unique_ptr<VirtualKey>> &keys() { return keys_; }
     bool checkOtherNecessaryImesExist(std::vector<fcitx::InputMethodGroupItem> &allItems);
 protected:


### PR DESCRIPTION
This fixes the problem mentioned here: https://github.com/clear-code/fcitx5-virtualkeyboard-ui/issues/2#issuecomment-1111704024

The 0th item in each group is usually set to a simple keyboard such as
`keyboard-us`, but most virtual keyboards using IME add-ons don't use
the 0th item and use only the 1th item, which is the IME for the
keyboard's language.

Such keyboards do not normally select the 0th item, but it is possible
that the 0th item is selected at the initiation of Fcitx5, so this
process is necessary.

This problem occurs when such a keyboard is set for the 0th group.
Example:
```
[Groups/0]
Name=CH
Default Layout=us
DefaultIM=pinyin

[Groups/0/Items/0]
Name=keyboard-us
Layout=

[Groups/0/Items/1]
Name=pinyin
Layout=

[GroupOrder]
0=CH
```
