### PR TITLE
Fix memleaks

### DIFF
--- a/src/virtualkeyboardanthy.cpp
+++ b/src/virtualkeyboardanthy.cpp
@@ -22,7 +22,7 @@ AnthyKeyboard::AnthyKeyboard()
         FCITX_INSTALL_PKGDATADIR "/virtualkeyboardui/virtualkeyboardui-ja.json";
     FCITX_KEYBOARD_LAYOUT()
         << "path of Japanese keyboard layout file: " << jsonPath;
-    loader_ = new KeyboardLayout(jsonPath);
+    loader_.reset(new KeyboardLayout(jsonPath));
 }
 #else
 AnthyKeyboard::AnthyKeyboard()
@@ -82,7 +82,7 @@ void AnthyKeyboard::setLayerKeys(size_t offset) {
     FCITX_KEYBOARD_LAYOUT()
         << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
 }
 #endif

--- a/src/virtualkeyboardanthy.h
+++ b/src/virtualkeyboardanthy.h
@@ -84,7 +84,7 @@ protected:
 private:
 #if USE_CUSTOM_LAYOUT
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
 #else
     void setTextRomajiKeys();
     void setMarkKeys();

--- a/src/virtualkeyboardchewing.cpp
+++ b/src/virtualkeyboardchewing.cpp
@@ -42,7 +42,7 @@ void ChewingKeyboard::setLayerKeys(size_t offset) {
     FCITX_KEYBOARD_LAYOUT()
         << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
 }
 #endif

--- a/src/virtualkeyboardchewing.h
+++ b/src/virtualkeyboardchewing.h
@@ -39,14 +39,14 @@ public:
             "/virtualkeyboardui/virtualkeyboardui-zh_TW.json";
         FCITX_KEYBOARD() << "path of Traditional chinese keyboard layout file: "
                          << jsonPath;
-        loader_ = new KeyboardLayout(jsonPath);
+        loader_.reset(new KeyboardLayout(jsonPath));
     }
 #endif
 
 private:
 #if USE_CUSTOM_LAYOUT
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
 #else
     void setTextKeys();
     void setMarkKeys();

--- a/src/virtualkeyboardcustom.cpp
+++ b/src/virtualkeyboardcustom.cpp
@@ -29,7 +29,8 @@ void CustomKeyboard::setLayerKeys(size_t offset) {
     FCITX_KEYBOARD_LAYOUT()
         << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        // move ownership to custom keyboard
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
     FCITX_KEYBOARD_LAYOUT()
         << "CustomKeyboard::setLayerKeys(): size of keys: " << keys_.size();

--- a/src/virtualkeyboardcustom.h
+++ b/src/virtualkeyboardcustom.h
@@ -40,7 +40,7 @@ public:
         }
         FCITX_KEYBOARD_LAYOUT()
             << "resolved full path of keyboard layout file: " << fullPath;
-        loader_ = new KeyboardLayout(fullPath);
+        loader_.reset(new KeyboardLayout(fullPath));
         loader_->loadMetadata(0);
         label_ = loader_->label();
         languageCode_ = std::string(loader_->languageCode());
@@ -62,7 +62,7 @@ private:
     const char *label_ = nullptr;
     std::string languageCode_;
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
     int mode_ = 0;
     bool isAdditionalMarkOn_ = false;
 };

--- a/src/virtualkeyboardhangul.cpp
+++ b/src/virtualkeyboardhangul.cpp
@@ -63,7 +63,7 @@ void HangulKeyboard::setLayerKeys(size_t offset) {
     FCITX_KEYBOARD_LAYOUT()
         << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
 }
 #else

--- a/src/virtualkeyboardhangul.h
+++ b/src/virtualkeyboardhangul.h
@@ -35,14 +35,14 @@ public:
         const char *jsonPath = FCITX_INSTALL_PKGDATADIR
             "/virtualkeyboardui/virtualkeyboardui-ko.json";
         FCITX_KEYBOARD() << "path of Korean keyboard layout file: " << jsonPath;
-        loader_ = new KeyboardLayout(jsonPath);
+        loader_.reset(new KeyboardLayout(jsonPath));
     }
 #endif
 
 private:
 #if USE_CUSTOM_LAYOUT
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
 #else
     void setTextKeys();
     void setMarkKeys();

--- a/src/virtualkeyboardlayout.h
+++ b/src/virtualkeyboardlayout.h
@@ -35,6 +35,16 @@ public:
         }
     }
 
+    ~KeyboardLayout() {
+        FCITX_KEYBOARD_LAYOUT() << "~KeyboardLayout()";
+        keys_.clear();
+        stateLabels_.clear();
+        modeLabels_.clear();
+        modeActions_.clear();
+        modeOffsets_.clear();
+        // decrement the reference count
+        json_object_put(json_);
+    }
     // Keyboard metadata
     const char *label() { return label_; }
     const char *languageCode() { return languageCode_; }
@@ -50,7 +60,7 @@ public:
     bool loadMetadata(size_t offset);
     bool loadKeyLayout(size_t offset);
     bool load(size_t offset);
-    std::vector<VirtualKey *> &keys() { return keys_; }
+    std::vector<std::unique_ptr<VirtualKey>> &keys() { return keys_; }
     std::string modeLabel(int mode) { return modeLabels_[mode]; }
     std::map<std::string, int> &modeActions() { return modeActions_; }
     std::map<std::string, int> &modeOffsets() { return modeOffsets_; }
@@ -58,7 +68,7 @@ public:
                             std::map<std::string, int> conditions);
 
 protected:
-    std::vector<VirtualKey *> keys_;
+    std::vector<std::unique_ptr<VirtualKey>> keys_;
     bool parseMetadata(size_t offset);
     double parseDouble(json_object *object);
     bool parseKeyboard(json_object *keyboard, size_t offset);

--- a/src/virtualkeyboardpinyin.cpp
+++ b/src/virtualkeyboardpinyin.cpp
@@ -85,7 +85,7 @@ void PinyinKeyboard::setLayerKeys(size_t offset) {
     FCITX_KEYBOARD_LAYOUT()
         << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
 }
 #else

--- a/src/virtualkeyboardpinyin.h
+++ b/src/virtualkeyboardpinyin.h
@@ -38,14 +38,14 @@ public:
         const char *jsonPath = FCITX_INSTALL_PKGDATADIR
             "/virtualkeyboardui/virtualkeyboardui-zh_CN.json";
         FCITX_KEYBOARD() << "path of Korean keyboard layout file: " << jsonPath;
-        loader_ = new KeyboardLayout(jsonPath);
+        loader_.reset(new KeyboardLayout(jsonPath));
     }
 #endif
 
 private:
 #if USE_CUSTOM_LAYOUT
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
 #else
     void setTextKeys();
     void setMarkKeys();

--- a/src/virtualkeyboardrussian.cpp
+++ b/src/virtualkeyboardrussian.cpp
@@ -65,7 +65,7 @@ void RussianKeyboard::setLayerKeys(size_t offset) {
     FCITX_KEYBOARD_LAYOUT()
         << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
 }
 #else

--- a/src/virtualkeyboardrussian.h
+++ b/src/virtualkeyboardrussian.h
@@ -36,14 +36,14 @@ public:
             "/virtualkeyboardui/virtualkeyboardui-ru.json";
         FCITX_KEYBOARD() << "path of Russian keyboard layout file: "
                          << jsonPath;
-        loader_ = new KeyboardLayout(jsonPath);
+        loader_.reset(new KeyboardLayout(jsonPath));
     }
 #endif
 
 private:
 #if USE_CUSTOM_LAYOUT
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
 #else
     void setCyrillicTextKeys();
     void setMarkKeys();

--- a/src/virtualkeyboardus.cpp
+++ b/src/virtualkeyboardus.cpp
@@ -59,7 +59,7 @@ void UsKeyboard::setLayerKeys(size_t offset) {
     loader_->load(offset);
     FCITX_KEYBOARD() << "loaded size of keys: " << loader_->keys().size();
     for (size_t i = 0; i < loader_->keys().size(); i++) {
-        keys_.emplace_back(loader_->keys()[i]);
+        keys_.emplace_back(std::move(loader_->keys()[i]));
     }
 }
 #else

--- a/src/virtualkeyboardus.h
+++ b/src/virtualkeyboardus.h
@@ -36,14 +36,14 @@ public:
             "/virtualkeyboardui/virtualkeyboardui-us.json";
         FCITX_KEYBOARD() << "path of English keyboard layout file: "
                          << jsonPath;
-        loader_ = new KeyboardLayout(jsonPath);
+        loader_.reset(new KeyboardLayout(jsonPath));
     }
 #endif
 
 private:
 #if USE_CUSTOM_LAYOUT
     void setLayerKeys(size_t offset);
-    KeyboardLayout *loader_;
+    std::unique_ptr<KeyboardLayout> loader_;
 #else
     void setTextKeys();
     void setMarkKeys();

--- a/test/testkeyboardutils.cpp
+++ b/test/testkeyboardutils.cpp
@@ -165,9 +165,12 @@ void KeyboardTester::testLoadKey(
             const char *expectedLabel =
                 static_cast<fcitx::classicui::NormalKey *>(expected[i])
                     ->label();
-            const char *actualLabel =
-                static_cast<fcitx::classicui::NormalKey *>(loader->keys()[i])
-                    ->label();
+            std::unique_ptr<fcitx::classicui::VirtualKey> virtualKey =
+                std::move(loader->keys()[i]);
+            fcitx::classicui::NormalKey *normalKey =
+                reinterpret_cast<fcitx::classicui::NormalKey *>(
+                    virtualKey.get());
+            const char *actualLabel = normalKey->label();
             // std::cout << "expected label: " << expectedLabel << std::endl;
             // std::cout << "actual label: " << actualLabel << std::endl;
             FCITX_ASSERT(!strcmp(expectedLabel, actualLabel));


### PR DESCRIPTION
Reduce definitely lost

Before:

```
  ==11333== LEAK SUMMARY:
  ==11333==    definitely lost: 47,787 bytes in 120 blocks
  ==11333==    indirectly lost: 11,202,985 bytes in 105,883 blocks
  ==11333==      possibly lost: 46,244 bytes in 682 blocks
  ==11333==    still reachable: 20,012,541 bytes in 82,152 blocks
  ==11333==                       of which reachable via heuristic:
  ==11333==                         length64           : 152,752 bytes in 377 blocks
  ==11333==                         newarray           : 1,568 bytes in 18 blocks
  ==11333==                         multipleinheritance: 3,816 bytes in 46 blocks
  ==11333==         suppressed: 0 bytes in 0 blocks
```

After:

```
  ==6933== LEAK SUMMARY:
  ==6933==    definitely lost: 47,179 bytes in 114 blocks
  ==6933==    indirectly lost: 9,690,169 bytes in 92,057 blocks
  ==6933==      possibly lost: 49,830 bytes in 715 blocks
  ==6933==    still reachable: 20,011,435 bytes in 82,143 blocks
  ==6933==                       of which reachable via heuristic:
  ==6933==                         length64           : 152,752 bytes in 377 blocks
  ==6933==                         newarray           : 1,568 bytes in 18 blocks
  ==6933==                         multipleinheritance: 14,040 bytes in 157 blocks
  ==6933==         suppressed: 0 bytes in 0 blocks
```
